### PR TITLE
Refactoring: specs

### DIFF
--- a/demo/pmatiello/tty/input_demo.clj
+++ b/demo/pmatiello/tty/input_demo.clj
@@ -19,13 +19,15 @@
   (when (full-render? old-state new-state)
     (tty.io/hide-cursor! output)
     (tty.io/clear-screen! output)
-    (tty.io/print! output header {:x 1 :y 1 :w 23 :h 3}))
+    (tty.io/print! output header
+                   #::tty.io{:row 1 :column 1 :width 23 :height 3}))
 
   (when (::tty/halt new-state)
     (tty.io/show-cursor! output))
 
-  (tty.io/print! output (:events new-state) {:x 1 :y 5 :w 45 :h 6})
-  (tty.io/place-cursor! output {:x 1 :y 10}))
+  (tty.io/print! output (:events new-state)
+                 #::tty.io{:row 5 :column 1 :width 45 :height 6})
+  (tty.io/place-cursor! output #::tty.io{:row 10 :column 1}))
 
 (defn handle [event]
   (swap! state assoc :events

--- a/demo/pmatiello/tty/input_demo.clj
+++ b/demo/pmatiello/tty/input_demo.clj
@@ -1,6 +1,7 @@
 (ns pmatiello.tty.input-demo
   (:require [pmatiello.tty :as tty]
-            [pmatiello.tty.io :as tty.io])
+            [pmatiello.tty.io :as tty.io]
+            [clojure.spec.test.alpha :as stest])
   (:import (clojure.lang ExceptionInfo)))
 
 (def ^:private state
@@ -25,7 +26,7 @@
   (when (::tty/halt new-state)
     (tty.io/show-cursor! output))
 
-  (tty.io/print! output (:events new-state)
+  (tty.io/print! output (map str (:events new-state))
                  #::tty.io{:row 5 :column 1 :width 45 :height 6})
   (tty.io/place-cursor! output #::tty.io{:row 10 :column 1}))
 
@@ -37,6 +38,7 @@
     (throw (ex-info "Interrupted" {:cause :interrupted}))))
 
 (defn -main []
+  (stest/instrument)
   (try
     (tty/init! handle render state)
     (catch ExceptionInfo ex

--- a/demo/pmatiello/tty/input_demo.clj
+++ b/demo/pmatiello/tty/input_demo.clj
@@ -28,7 +28,7 @@
     (tty.io/show-cursor! output))
 
   (tty.io/print! output (map str (:events new-state))
-                 #::tty.io{:row 5 :column 1 :width 60 :height 6})
+                 #::tty.io{:row 5 :column 1 :width 80 :height 6})
   (tty.io/place-cursor! output #::tty.io{:row 10 :column 1}))
 
 (defn handle [event]

--- a/demo/pmatiello/tty/input_demo.clj
+++ b/demo/pmatiello/tty/input_demo.clj
@@ -1,6 +1,6 @@
 (ns pmatiello.tty.input-demo
   (:require [pmatiello.tty.core :as tty.core]
-            [pmatiello.tty.lifecycle :as tty.lifecycle]
+            [pmatiello.tty.event :as tty.event]
             [pmatiello.tty.io :as tty.io]
             [clojure.spec.test.alpha :as stest])
   (:import (clojure.lang ExceptionInfo)))
@@ -14,8 +14,8 @@
    "Enter Ctrl+D to quit."])
 
 (defn- full-render? [old new]
-  (or (nil? (::tty.lifecycle/init old))
-      (not= (::tty.lifecycle/size old) (::tty.lifecycle/size new))))
+  (or (nil? (::tty.event/init old))
+      (not= (::tty.event/size old) (::tty.event/size new))))
 
 (defn- render [output old-state new-state]
   (when (full-render? old-state new-state)
@@ -24,7 +24,7 @@
     (tty.io/print! output header
                    #::tty.io{:row 1 :column 1 :width 23 :height 3}))
 
-  (when (::tty.lifecycle/halt new-state)
+  (when (::tty.event/halt new-state)
     (tty.io/show-cursor! output))
 
   (tty.io/print! output (map str (:events new-state))
@@ -35,7 +35,7 @@
   (swap! state assoc :events
          (->> event (conj (:events @state)) (take 5)))
 
-  (when (-> event :value #{:eot})
+  (when (-> event ::tty.event/value #{:eot})
     (throw (ex-info "Interrupted" {:cause :interrupted}))))
 
 (defn -main []

--- a/demo/pmatiello/tty/input_demo.clj
+++ b/demo/pmatiello/tty/input_demo.clj
@@ -1,5 +1,6 @@
 (ns pmatiello.tty.input-demo
-  (:require [pmatiello.tty :as tty]
+  (:require [pmatiello.tty.core :as tty.core]
+            [pmatiello.tty.lifecycle :as tty.lifecycle]
             [pmatiello.tty.io :as tty.io]
             [clojure.spec.test.alpha :as stest])
   (:import (clojure.lang ExceptionInfo)))
@@ -13,8 +14,8 @@
    "Enter Ctrl+D to quit."])
 
 (defn- full-render? [old new]
-  (or (nil? (::tty/init old))
-      (not= (::tty/size old) (::tty/size new))))
+  (or (nil? (::tty.lifecycle/init old))
+      (not= (::tty.lifecycle/size old) (::tty.lifecycle/size new))))
 
 (defn- render [output old-state new-state]
   (when (full-render? old-state new-state)
@@ -23,11 +24,11 @@
     (tty.io/print! output header
                    #::tty.io{:row 1 :column 1 :width 23 :height 3}))
 
-  (when (::tty/halt new-state)
+  (when (::tty.lifecycle/halt new-state)
     (tty.io/show-cursor! output))
 
   (tty.io/print! output (map str (:events new-state))
-                 #::tty.io{:row 5 :column 1 :width 45 :height 6})
+                 #::tty.io{:row 5 :column 1 :width 60 :height 6})
   (tty.io/place-cursor! output #::tty.io{:row 10 :column 1}))
 
 (defn handle [event]
@@ -40,7 +41,7 @@
 (defn -main []
   (stest/instrument)
   (try
-    (tty/init! handle render state)
+    (tty.core/init! handle render state)
     (catch ExceptionInfo ex
       (if (-> ex ex-data :cause #{:interrupted})
         (System/exit 0)

--- a/src/pmatiello/tty.clj
+++ b/src/pmatiello/tty.clj
@@ -1,10 +1,27 @@
 (ns pmatiello.tty
   (:require [pmatiello.tty.internal.ansi.input :as input]
             [pmatiello.tty.internal.io :as io]
-            [pmatiello.tty.internal.mainloop :as mainloop])
-  (:import (java.io Writer)))
+            [pmatiello.tty.internal.mainloop :as mainloop]
+            [clojure.spec.alpha :as s])
+  (:import (java.io Writer)
+           (clojure.lang Atom)))
+
+(s/def ::state
+  (s/and #(instance? Atom %)
+         #(-> % deref map?)))
 
 (defn init!
+  "Initializes the application main loop.
+
+  handle-fn: function invoked for each input event. Args:
+    - event
+
+  render-fn: function invoked for each change in state. Args:
+    - output: a #::tty.io/output object
+    - old-state: previous ::state
+    - new-state: updated ::state
+
+  state: mutable application state"
   [handle-fn render-fn state]
   (let [input (input/reader->event-seq *in*)
         output! (partial io/write! *out*)]
@@ -12,3 +29,6 @@
       [*out* (Writer/nullWriter)]
       (io/with-raw-tty
         #(mainloop/with-mainloop handle-fn render-fn state input output!)))))
+
+(s/fdef init!
+  :args (s/cat :handle-fn fn? :render-fn fn? :state ::state))

--- a/src/pmatiello/tty/core.clj
+++ b/src/pmatiello/tty/core.clj
@@ -1,4 +1,4 @@
-(ns pmatiello.tty
+(ns pmatiello.tty.core
   (:require [pmatiello.tty.internal.ansi.input :as input]
             [pmatiello.tty.internal.io :as io]
             [pmatiello.tty.internal.mainloop :as mainloop]

--- a/src/pmatiello/tty/core.clj
+++ b/src/pmatiello/tty/core.clj
@@ -2,13 +2,9 @@
   (:require [pmatiello.tty.internal.ansi.input :as input]
             [pmatiello.tty.internal.io :as io]
             [pmatiello.tty.internal.mainloop :as mainloop]
+            [pmatiello.tty.state :as tty.state]
             [clojure.spec.alpha :as s])
-  (:import (java.io Writer)
-           (clojure.lang Atom)))
-
-(s/def ::state
-  (s/and #(instance? Atom %)
-         #(-> % deref map?)))
+  (:import (java.io Writer)))
 
 (defn init!
   "Initializes the application main loop.
@@ -17,9 +13,9 @@
     - event
 
   render-fn: function invoked for each change in state. Args:
-    - output: a #::tty.io/output object
-    - old-state: previous ::state
-    - new-state: updated ::state
+    - output: a ::tty.io/output-buf object
+    - old-state: previous ::tty.state/state
+    - new-state: updated ::tty.state/state
 
   state: mutable application state"
   [handle-fn render-fn state]
@@ -31,4 +27,4 @@
         #(mainloop/with-mainloop handle-fn render-fn state input output!)))))
 
 (s/fdef init!
-  :args (s/cat :handle-fn fn? :render-fn fn? :state ::state))
+  :args (s/cat :handle-fn fn? :render-fn fn? :state ::tty.state/state))

--- a/src/pmatiello/tty/event.clj
+++ b/src/pmatiello/tty/event.clj
@@ -4,6 +4,7 @@
 (s/def ::event
   (s/keys :req [::type ::value]))
 
-(s/def ::type keyword?)
+(s/def ::type
+  #{::init ::halt ::size ::keypress ::cursor-position ::unknown})
 
 (s/def ::value any?)

--- a/src/pmatiello/tty/event.clj
+++ b/src/pmatiello/tty/event.clj
@@ -1,4 +1,9 @@
 (ns pmatiello.tty.event
   (:require [clojure.spec.alpha :as s]))
 
-(s/def ::event any?)
+(s/def ::event
+  (s/keys :req [::type ::value]))
+
+(s/def ::type keyword?)
+
+(s/def ::value any?)

--- a/src/pmatiello/tty/event.clj
+++ b/src/pmatiello/tty/event.clj
@@ -1,0 +1,4 @@
+(ns pmatiello.tty.event
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::event any?)

--- a/src/pmatiello/tty/internal/ansi/input.clj
+++ b/src/pmatiello/tty/internal/ansi/input.clj
@@ -9,8 +9,8 @@
   "Converts input from reader into a lazy sequence of events"
   [^Reader reader]
   (->> reader
-       input.parsing/reader->input-seq
-       input.parsing/input-seq->event-seq))
+       input.parsing/reader->char-seq
+       input.parsing/char-seq->event-seq))
 
 (s/fdef reader->event-seq
   :args (s/cat :reader #(instance? Reader %))

--- a/src/pmatiello/tty/internal/ansi/input.clj
+++ b/src/pmatiello/tty/internal/ansi/input.clj
@@ -1,8 +1,17 @@
 (ns pmatiello.tty.internal.ansi.input
-  (:require [pmatiello.tty.internal.ansi.input.parsing :as input.parsing])
+  (:require [pmatiello.tty.internal.ansi.input.parsing :as input.parsing]
+            [clojure.spec.alpha :as s])
   (:import (java.io Reader)))
 
-(defn reader->event-seq [^Reader reader]
+(s/def ::event-seq sequential?)
+
+(defn reader->event-seq
+  "Converts input from reader into a lazy sequence of events"
+  [^Reader reader]
   (->> reader
        input.parsing/reader->input-seq
        input.parsing/input-seq->event-seq))
+
+(s/fdef reader->event-seq
+  :args (s/cat :reader #(instance? Reader %))
+  :ret ::event-seq)

--- a/src/pmatiello/tty/internal/ansi/input/event.clj
+++ b/src/pmatiello/tty/internal/ansi/input/event.clj
@@ -79,7 +79,7 @@
           column    (->> pos-chars (drop-while #(not= % 59)) (drop 1) (map char) str/join Integer/parseInt)]
       {:event :cursor-position :value [line column]})))
 
-(defn key-codes->event [key-codes]
+(defn char-codes->event [key-codes]
   (or (special-key key-codes)
       (regular-key key-codes)
       (device-status-report key-codes)

--- a/src/pmatiello/tty/internal/mainloop.clj
+++ b/src/pmatiello/tty/internal/mainloop.clj
@@ -1,6 +1,5 @@
 (ns pmatiello.tty.internal.mainloop
-  (:require [pmatiello.tty.lifecycle :as lifecycle]
-            [pmatiello.tty.event :as event]
+  (:require [pmatiello.tty.event :as event]
             [pmatiello.tty.state :as state]
             [pmatiello.tty.internal.signal :as signal]
             [pmatiello.tty.internal.ansi.cursor :as cursor]
@@ -59,7 +58,7 @@
   [handle-fn render-fn state input output!]
   (try
     (add-watch state ::state-changed (watch-fn render-fn output!))
-    (notify! handle-fn state #::event{:type ::lifecycle/init :value true})
+    (notify! handle-fn state #::event{:type ::event/init :value true})
 
     (signal/trap :winch (partial tty-size?! output!))
     (tty-size?! output! nil)
@@ -67,12 +66,12 @@
     (doseq [event input]
       (case (::event/type event)
         ::event/cursor-position
-        (notify! handle-fn state (assoc event ::event/type ::lifecycle/size))
+        (notify! handle-fn state (assoc event ::event/type ::event/size))
 
         (call-sync! handle-fn event)))
 
     (finally
-      (notify! handle-fn state #::event{:type ::lifecycle/halt :value true})
+      (notify! handle-fn state #::event{:type ::event/halt :value true})
       (remove-watch state ::state-changed))))
 
 (s/fdef with-mainloop

--- a/src/pmatiello/tty/internal/mainloop.clj
+++ b/src/pmatiello/tty/internal/mainloop.clj
@@ -1,5 +1,6 @@
 (ns pmatiello.tty.internal.mainloop
-  (:require [pmatiello.tty.internal.signal :as signal]
+  (:require [pmatiello.tty.lifecycle :as tty.lifecycle]
+            [pmatiello.tty.internal.signal :as signal]
             [pmatiello.tty.internal.ansi.cursor :as cursor]))
 
 (defn- watch-fn [render-fn output!]
@@ -23,7 +24,7 @@
   [handle-fn render-fn state input output!]
   (try
     (add-watch state ::state-changed (watch-fn render-fn output!))
-    (notify! handle-fn state :pmatiello.tty/init true)
+    (notify! handle-fn state ::tty.lifecycle/init true)
 
     (signal/trap :winch (partial tty-size?! output!))
     (tty-size?! output! nil)
@@ -31,10 +32,10 @@
     (doseq [event input]
       (case (:event event)
         :cursor-position
-        (notify! handle-fn state :pmatiello.tty/size (:value event))
+        (notify! handle-fn state ::tty.lifecycle/size (:value event))
 
         (call-sync! handle-fn event)))
 
     (finally
-      (notify! handle-fn state :pmatiello.tty/halt true)
+      (notify! handle-fn state ::tty.lifecycle/halt true)
       (remove-watch state ::state-changed))))

--- a/src/pmatiello/tty/internal/mainloop.clj
+++ b/src/pmatiello/tty/internal/mainloop.clj
@@ -4,6 +4,7 @@
             [pmatiello.tty.state :as tty.state]
             [pmatiello.tty.internal.signal :as signal]
             [pmatiello.tty.internal.ansi.cursor :as cursor]
+            [pmatiello.tty.internal.ansi.input :as input]
             [clojure.spec.alpha :as s]))
 
 (defn- watch-fn
@@ -76,4 +77,4 @@
 
 (s/fdef with-mainloop
   :args (s/cat :handle-fn fn? :render-fn fn? :state ::tty.state/state
-               :input sequential? :output! fn?))
+               :input ::input/event-seq :output! fn?))

--- a/src/pmatiello/tty/internal/mainloop.clj
+++ b/src/pmatiello/tty/internal/mainloop.clj
@@ -1,26 +1,60 @@
 (ns pmatiello.tty.internal.mainloop
   (:require [pmatiello.tty.lifecycle :as tty.lifecycle]
+            [pmatiello.tty.state :as tty.state]
+            [pmatiello.tty.event :as tty.event]
             [pmatiello.tty.internal.signal :as signal]
-            [pmatiello.tty.internal.ansi.cursor :as cursor]))
+            [pmatiello.tty.internal.ansi.cursor :as cursor]
+            [clojure.spec.alpha :as s]))
 
-(defn- watch-fn [render-fn output!]
+(defn- watch-fn
+  "Produces a watch function for an atom such that render-fn is invoked with the arguments:
+    - ::tty.io/output-buf, old-state, new-state.
+
+  After render-fn finishes, writes the output-buf (calling output!)."
+  [render-fn output!]
   (fn [_ _ old-state new-state]
     (let [output (atom [])]
       (render-fn output old-state new-state)
       (output! @output))))
 
-(defn- call-sync! [handle-fn event]
-  (locking handle-fn
-    (handle-fn event)))
+(s/fdef watch-fn
+  :args (s/cat :render-fn fn? :output fn?)
+  :ret fn?)
 
-(defn- notify! [handle-fn state event value]
+(defn- call-sync!
+  "Invokes func with event as argument, serially."
+  [func & args]
+  (locking func
+    (apply func args)))
+
+(s/fdef call-sync!
+  :args (s/cat :func fn? :args (s/* any?)))
+
+(defn- notify!
+  "Notify functions of an event."
+  [handle-fn state event value]
   (call-sync! handle-fn {:event event :value value})
   (swap! state assoc event value))
 
-(defn- tty-size?! [output! _signal]
+(s/fdef notify!
+  :args (s/cat :handle-fn fn? :state ::tty.state/state :event ::tty.event/event :value any?))
+
+(defn- tty-size?!
+  "Requests tty size."
+  [output! _signal]
   (output! [(cursor/position 9999 9999) cursor/current-position]))
 
+(s/fdef tty-size?!
+  :args (s/cat :output! fn? :_signal any?))
+
 (defn with-mainloop
+  "Starts the main loop.
+
+  handle-fn: input event handler function.
+  render-fn: output rendering function.
+  state: mutable application state
+  input: sequence of input events
+  output!: function for writing to the output stream."
   [handle-fn render-fn state input output!]
   (try
     (add-watch state ::state-changed (watch-fn render-fn output!))
@@ -39,3 +73,7 @@
     (finally
       (notify! handle-fn state ::tty.lifecycle/halt true)
       (remove-watch state ::state-changed))))
+
+(s/fdef with-mainloop
+  :args (s/cat :handle-fn fn? :render-fn fn? :state ::tty.state/state
+               :input sequential? :output! fn?))

--- a/src/pmatiello/tty/internal/signal.clj
+++ b/src/pmatiello/tty/internal/signal.clj
@@ -1,9 +1,20 @@
 (ns pmatiello.tty.internal.signal
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s])
   (:import (sun.misc Signal SignalHandler)))
 
-(defn trap [signal callback-fn]
+(s/def ::signal keyword?)
+
+(defn trap
+  "Registers a signal handler.
+
+  signal: signal name
+  handler-fn: handler function. Receives the signal name as argument."
+  [signal handler-fn]
   (Signal/handle
     (->> signal name str/upper-case Signal.)
     (reify SignalHandler
-      (handle [_this _signal] (callback-fn signal)))))
+      (handle [_this _signal] (handler-fn signal)))))
+
+(s/fdef trap
+  :args (s/cat :signal ::signal :handler-fn fn?))

--- a/src/pmatiello/tty/internal/stty.clj
+++ b/src/pmatiello/tty/internal/stty.clj
@@ -1,27 +1,51 @@
 (ns pmatiello.tty.internal.stty
   (:require [clojure.java.shell :as shell]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [clojure.spec.alpha :as s]))
 
-(defn ^:private sh! [& args]
-  (let [command  (string/join " " args)
-        result   (shell/sh "/bin/sh" "-c" command)
+(s/def ::settings (s/map-of ::flag ::value))
+(s/def ::flag keyword?)
+(s/def ::value (s/or :nil nil? :string string?))
+
+(defn ^:private sh!
+  "Executes the given shell command."
+  [& args]
+  (let [command (string/join " " args)
+        result (shell/sh "/bin/sh" "-c" command)
         success? (-> result :exit zero?)]
     (when-not success?
       (throw (ex-info "Shell command execution failed"
                       {:command command :result result})))
     (:out result)))
 
-(defn ^:private stty-part->map [part]
+(s/fdef sh!
+  :args (s/cat :args (s/* string?))
+  :ret string?)
+
+(defn ^:private stty-part->map
+  "Parses a single tty setting."
+  [part]
   (let [[k v] (string/split part #"=")]
     {(keyword k) v}))
 
-(defn current []
-  (let [stty-str   (-> (sh! "stty -g < /dev/tty") string/trim-newline)
+(s/fdef stty-part->map
+  :args (s/cat :part string?)
+  :ret ::settings)
+
+(defn current
+  "Returns current tty settings."
+  []
+  (let [stty-str (-> (sh! "stty -g < /dev/tty") string/trim-newline)
         stty-parts (string/split stty-str #":")
-        stty-maps  (map stty-part->map stty-parts)]
+        stty-maps (map stty-part->map stty-parts)]
     (apply merge stty-maps)))
 
-(defn apply! [settings]
+(s/fdef current
+  :ret ::settings)
+
+(defn apply!
+  "Applies the given tty settings."
+  [settings]
   (let [stty-args (->> settings
                        (map identity)
                        (map #(remove nil? %))
@@ -30,13 +54,26 @@
                        (string/join ":"))]
     (sh! "stty" stty-args "< /dev/tty")))
 
-(defn set-flags! [& flags]
+(s/fdef apply!
+  :args (s/cat :settings ::settings))
+
+(defn set-flags!
+  "Sets the given tty flags."
+  [& flags]
   (let [stty-args (->> flags (map name) (string/join " "))]
     (sh! "stty" stty-args "< /dev/tty")))
 
-(defn unset-flags! [& flags]
+(s/fdef set-flags!
+  :args (s/cat :flags (s/* ::flag)))
+
+(defn unset-flags!
+  "Unsets the given tty flags."
+  [& flags]
   (let [stty-args (->> flags
                        (map name)
                        (map #(string/replace % #"^" "-"))
                        (string/join " "))]
     (sh! "stty" stty-args "< /dev/tty")))
+
+(s/fdef unset-flags!
+  :args (s/cat :flags (s/* ::flag)))

--- a/src/pmatiello/tty/io.clj
+++ b/src/pmatiello/tty/io.clj
@@ -1,41 +1,112 @@
 (ns pmatiello.tty.io
   (:require [pmatiello.tty.internal.ansi.cursor :as cursor]
-            [pmatiello.tty.internal.ansi.erase :as erase]))
+            [pmatiello.tty.internal.ansi.erase :as erase]
+            [clojure.spec.alpha :as s])
+  (:import (clojure.lang Atom)))
 
-(defn- cropped-height [height buffer]
+(s/def ::output
+  (s/and #(instance? Atom %)
+         #(-> % deref sequential?)))
+
+(s/def ::document (s/and vector? (s/coll-of ::paragraph)))
+(s/def ::paragraph string?)
+
+(s/def ::window
+  (s/keys :req [::row ::column ::width ::height]))
+
+(s/def ::coordinates
+  (s/keys :req [::row ::column]))
+
+(s/def ::row int?)
+(s/def ::column int?)
+(s/def ::width int?)
+(s/def ::height int?)
+
+(defn- cropped-height
+  "Crops the document at the given height.
+  Completes remaining rows with blank characters."
+  [document height]
   (let [blank (repeat height "")]
-    (->> (concat buffer blank)
+    (->> (concat document blank)
          (take height))))
 
-(defn- cropped-width [width buffer-line]
+(s/fdef cropped-height
+  :args (s/cat :document ::document :height ::height)
+  :ret ::document)
+
+(defn- cropped-width
+  "Crops the document at the given width.
+  Completes remaining columns with blank characters."
+  [line width]
   (let [blank (->> " " (repeat width) (apply str))]
-    (-> buffer-line (str blank) (subs 0 width))))
+    (-> line (str blank) (subs 0 width))))
 
-(defn- cropped [buffer width height]
-  (->> buffer
-       (cropped-height height)
-       (map #(cropped-width width %))))
+(s/fdef cropped-width
+  :args (s/cat :line ::paragraph :width ::width)
+  :ret ::paragraph)
 
-(defn- into-output! [output each]
-  (swap! output conj each))
+(defn- cropped
+  "Crops the document at the given width and height.
+  Completes remaining rows and columns with blank characters."
+  [document width height]
+  (->> (cropped-height document height)
+       (map #(cropped-width % width))))
 
-(defn print! [output lines window]
-  (let [{:keys [x y w h]} window
-        cropped-lines (cropped lines w h)
+(s/fdef cropped
+  :args (s/cat :document ::document :width ::width :height ::height)
+  :ret ::document)
+
+(defn- into-output!
+  "Adds string to the list of output writes."
+  [output string]
+  (swap! output conj string))
+
+(s/fdef into-output!
+  :args (s/cat :output ::output :string string?))
+
+(defn print!
+  "Prints the given document to output at the given window."
+  [output document window]
+  (let [{::keys [row column width height]} window
+        cropped-lines (cropped document width height)
         indexed-lines (map vector (range) cropped-lines)]
     (doseq [[offset ^String line] indexed-lines]
-      (into-output! output (str (cursor/position (+ y offset) x) line)))))
+      (into-output! output (str (cursor/position (+ row offset) column) line)))))
 
-(defn clear-screen! [output]
+(s/fdef print!
+  :args (s/cat :output ::output :document ::document :window ::window))
+
+(defn clear-screen!
+  "Clears the screen completely."
+  [output]
   (into-output! output erase/all)
   (into-output! output (cursor/position 1 1)))
 
-(defn show-cursor! [output]
+(s/fdef clear-screen!
+  :args (s/cat :output ::output))
+
+(defn show-cursor!
+  "Makes the cursor visible."
+  [output]
   (into-output! output cursor/show))
 
-(defn hide-cursor! [output]
+(s/fdef show-cursor!
+  :args (s/cat :output ::output))
+
+(defn hide-cursor!
+  "Makes the cursor invisible."
+  [output]
   (into-output! output cursor/hide))
 
-(defn place-cursor! [output coords]
-  (let [{:keys [x y]} coords]
-    (into-output! output (cursor/position y x))))
+(s/fdef hide-cursor!
+  :args (s/cat :output ::output))
+
+(defn place-cursor!
+  "Places the cursor at the given coordinates."
+  [output coordinates]
+  (let [{::keys [column row]} coordinates]
+    (into-output! output (cursor/position row column))))
+
+(s/fdef place-cursor!
+  :args (s/cat :output ::output :coordinates ::coordinates)
+  :ret ::document)

--- a/src/pmatiello/tty/io.clj
+++ b/src/pmatiello/tty/io.clj
@@ -8,7 +8,7 @@
   (s/and #(instance? Atom %)
          #(-> % deref sequential?)))
 
-(s/def ::document (s/and vector? (s/coll-of ::paragraph)))
+(s/def ::document (s/and sequential? (s/coll-of ::paragraph)))
 (s/def ::paragraph string?)
 
 (s/def ::window

--- a/src/pmatiello/tty/lifecycle.clj
+++ b/src/pmatiello/tty/lifecycle.clj
@@ -1,5 +1,0 @@
-(ns pmatiello.tty.lifecycle
-  (:require [clojure.spec.alpha :as s]))
-
-(s/def ::lifecycle-events
-  #{::init ::halt ::size})

--- a/src/pmatiello/tty/lifecycle.clj
+++ b/src/pmatiello/tty/lifecycle.clj
@@ -1,0 +1,5 @@
+(ns pmatiello.tty.lifecycle
+  (:require [clojure.spec.alpha :as s]))
+
+(s/def ::lifecycle-events
+  #{::init ::halt ::size})

--- a/src/pmatiello/tty/state.clj
+++ b/src/pmatiello/tty/state.clj
@@ -1,0 +1,7 @@
+(ns pmatiello.tty.state
+  (:require [clojure.spec.alpha :as s])
+  (:import (clojure.lang Atom)))
+
+(s/def ::state
+  (s/and #(instance? Atom %)
+         #(-> % deref map?)))

--- a/test/pmatiello/tty/internal/ansi/input/event_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input/event_test.clj
@@ -1,40 +1,49 @@
 (ns pmatiello.tty.internal.ansi.input.event-test
   (:require [clojure.test :refer :all])
-  (:require [pmatiello.tty.internal.ansi.input.event :as input.event]))
+  (:require [pmatiello.tty.internal.ansi.input.event :as input.event]
+            [pmatiello.tty.event :as event]
+            [pmatiello.tty.internal.fixtures :as fixtures]
+            [clojure.spec.alpha :as s]))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (deftest char-codes->event
   (testing "maps regular key to char"
-    (is (= {:event :keypress :value "A"}
+    (is (= #::event{:type ::event/keypress :value "A"}
            (input.event/char-codes->event [65])))
-    (is (= {:event :keypress :value "B"}
+    (is (= #::event{:type ::event/keypress :value "B"}
            (input.event/char-codes->event [66])))
-    (is (= {:event :keypress :value "C"}
-           (input.event/char-codes->event [67]))))
+    (is (= #::event{:type ::event/keypress :value "C"}
+           (input.event/char-codes->event [67])))
+    (is (s/valid? ::event/event
+                  (input.event/char-codes->event [65]))))
 
   (testing "maps special key to char"
-    (is (= {:event :keypress :value :nul}
+    (is (= #::event{:type ::event/keypress :value :nul}
            (input.event/char-codes->event [0])))
-    (is (= {:event :keypress :value :eot}
+    (is (= #::event{:type ::event/keypress :value :eot}
            (input.event/char-codes->event [4])))
-    (is (= {:event :keypress :value :lf}
+    (is (= #::event{:type ::event/keypress :value :lf}
            (input.event/char-codes->event [10])))
-    (is (= {:event :keypress :value :esc}
-           (input.event/char-codes->event [27]))))
+    (is (= #::event{:type ::event/keypress :value :esc}
+           (input.event/char-codes->event [27])))
+    (is (s/valid? ::event/event
+                  (input.event/char-codes->event [0]))))
 
   (testing "maps escape sequences"
-    (is (= {:event :keypress :value :up}
+    (is (= #::event{:type ::event/keypress :value :up}
            (input.event/char-codes->event [27 91 65])))
-    (is (= {:event :keypress :value :right}
+    (is (= #::event{:type ::event/keypress :value :right}
            (input.event/char-codes->event [27 91 67])))
-    (is (= {:event :keypress :value :f1}
+    (is (= #::event{:type ::event/keypress :value :f1}
            (input.event/char-codes->event [27 79 80])))
-    (is (= {:event :keypress :value :f5}
+    (is (= #::event{:type ::event/keypress :value :f5}
            (input.event/char-codes->event [27 91 49 53 126]))))
 
   (testing "decodes and stores current cursor position"
-    (is (= {:event :cursor-position :value [12 34]}
+    (is (= #::event{:type ::event/cursor-position :value [12 34]}
            (input.event/char-codes->event [27 91 49 50 59 51 52 82]))))
 
   (testing "maps unknown keys to :unknown"
-    (is (= {:event :unknown :value [27 99 99]}
+    (is (= #::event{:type ::event/unknown :value [27 99 99]}
            (input.event/char-codes->event [27 99 99])))))

--- a/test/pmatiello/tty/internal/ansi/input/event_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input/event_test.clj
@@ -2,39 +2,39 @@
   (:require [clojure.test :refer :all])
   (:require [pmatiello.tty.internal.ansi.input.event :as input.event]))
 
-(deftest key-codes->event
+(deftest char-codes->event
   (testing "maps regular key to char"
     (is (= {:event :keypress :value "A"}
-           (input.event/key-codes->event [65])))
+           (input.event/char-codes->event [65])))
     (is (= {:event :keypress :value "B"}
-           (input.event/key-codes->event [66])))
+           (input.event/char-codes->event [66])))
     (is (= {:event :keypress :value "C"}
-           (input.event/key-codes->event [67]))))
+           (input.event/char-codes->event [67]))))
 
   (testing "maps special key to char"
     (is (= {:event :keypress :value :nul}
-           (input.event/key-codes->event [0])))
+           (input.event/char-codes->event [0])))
     (is (= {:event :keypress :value :eot}
-           (input.event/key-codes->event [4])))
+           (input.event/char-codes->event [4])))
     (is (= {:event :keypress :value :lf}
-           (input.event/key-codes->event [10])))
+           (input.event/char-codes->event [10])))
     (is (= {:event :keypress :value :esc}
-           (input.event/key-codes->event [27]))))
+           (input.event/char-codes->event [27]))))
 
   (testing "maps escape sequences"
     (is (= {:event :keypress :value :up}
-           (input.event/key-codes->event [27 91 65])))
+           (input.event/char-codes->event [27 91 65])))
     (is (= {:event :keypress :value :right}
-           (input.event/key-codes->event [27 91 67])))
+           (input.event/char-codes->event [27 91 67])))
     (is (= {:event :keypress :value :f1}
-           (input.event/key-codes->event [27 79 80])))
+           (input.event/char-codes->event [27 79 80])))
     (is (= {:event :keypress :value :f5}
-           (input.event/key-codes->event [27 91 49 53 126]))))
+           (input.event/char-codes->event [27 91 49 53 126]))))
 
   (testing "decodes and stores current cursor position"
     (is (= {:event :cursor-position :value [12 34]}
-           (input.event/key-codes->event [27 91 49 50 59 51 52 82]))))
+           (input.event/char-codes->event [27 91 49 50 59 51 52 82]))))
 
   (testing "maps unknown keys to :unknown"
     (is (= {:event :unknown :value [27 99 99]}
-           (input.event/key-codes->event [27 99 99])))))
+           (input.event/char-codes->event [27 99 99])))))

--- a/test/pmatiello/tty/internal/ansi/input/parsing_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input/parsing_test.clj
@@ -1,54 +1,57 @@
 (ns pmatiello.tty.internal.ansi.input.parsing-test
   (:require [clojure.test :refer :all]
-            [pmatiello.tty.internal.ansi.input.parsing :as input.parsing])
+            [pmatiello.tty.internal.ansi.input.parsing :as input.parsing]
+            [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (java.io StringReader)))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (deftest input-seq->event-seq-test
   (testing "decodes regular characters"
     (is (= [{:event :keypress :value "A"}
             {:event :keypress :value "B"}
             {:event :keypress :value "C"}]
-           (input.parsing/input-seq->event-seq
-             [{:char-code 65 :has-next? false}
-              {:char-code 66 :has-next? false}
-              {:char-code 67 :has-next? false}]))))
+           (input.parsing/char-seq->event-seq
+             [#::input.parsing{:char-code 65 :has-next? false}
+              #::input.parsing{:char-code 66 :has-next? false}
+              #::input.parsing{:char-code 67 :has-next? false}]))))
 
   (testing "decodes control characters"
     (is (= [{:event :keypress :value :nul}]
-           (input.parsing/input-seq->event-seq
-             [{:char-code 0 :has-next? false}]))))
+           (input.parsing/char-seq->event-seq
+             [#::input.parsing{:char-code 0 :has-next? false}]))))
 
   (testing "decodes escape sequences"
     (is (= [{:event :keypress :value :up}]
-           (input.parsing/input-seq->event-seq
-             [{:char-code 27, :has-next? true}
-              {:char-code 91, :has-next? true}
-              {:char-code 65, :has-next? false}]))))
+           (input.parsing/char-seq->event-seq
+             [#::input.parsing{:char-code 27, :has-next? true}
+              #::input.parsing{:char-code 91, :has-next? true}
+              #::input.parsing{:char-code 65, :has-next? false}]))))
 
   (testing "returns :unknown when escape sequence is not recognised"
     (is (= [{:event :unknown :value [27 99 99]}]
-           (input.parsing/input-seq->event-seq
-             [{:char-code 27, :has-next? true}
-              {:char-code 99, :has-next? true}
-              {:char-code 99, :has-next? false}]))))
+           (input.parsing/char-seq->event-seq
+             [#::input.parsing{:char-code 27, :has-next? true}
+              #::input.parsing{:char-code 99, :has-next? true}
+              #::input.parsing{:char-code 99, :has-next? false}]))))
 
   (testing "splits multiple buffered escape sequences"
-    (is (= [{:event :keypress :value :up}
-            {:event :keypress :value :esc}
-            {:event :keypress :value :down}]
-           (input.parsing/input-seq->event-seq
-             [{:char-code 27, :has-next? true}
-              {:char-code 91, :has-next? true}
-              {:char-code 65, :has-next? true}
-              {:char-code 27, :has-next? true}
-              {:char-code 27, :has-next? true}
-              {:char-code 91, :has-next? true}
-              {:char-code 66, :has-next? false}])))))
+      (is (= [{:event :keypress :value :up}
+              {:event :keypress :value :esc}
+              {:event :keypress :value :down}]
+             (input.parsing/char-seq->event-seq
+               [#::input.parsing{:char-code 27, :has-next? true}
+                #::input.parsing{:char-code 91, :has-next? true}
+                #::input.parsing{:char-code 65, :has-next? true}
+                #::input.parsing{:char-code 27, :has-next? true}
+                #::input.parsing{:char-code 27, :has-next? true}
+                #::input.parsing{:char-code 91, :has-next? true}
+                #::input.parsing{:char-code 66, :has-next? false}])))))
 
-(deftest reader->input-seq-test
-  (is (= [{:char-code 105, :has-next? true}
-          {:char-code 110, :has-next? true}
-          {:char-code 112, :has-next? true}
-          {:char-code 117, :has-next? true}
-          {:char-code 116, :has-next? true}]
-         (-> "input" StringReader. input.parsing/reader->input-seq))))
+(deftest reader->char-seq
+  (is (= [#::input.parsing{:char-code 105, :has-next? true}
+          #::input.parsing{:char-code 110, :has-next? true}
+          #::input.parsing{:char-code 112, :has-next? true}
+          #::input.parsing{:char-code 117, :has-next? true}
+          #::input.parsing{:char-code 116, :has-next? true}]
+         (-> "input" StringReader. input.parsing/reader->char-seq))))

--- a/test/pmatiello/tty/internal/ansi/input/parsing_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input/parsing_test.clj
@@ -1,6 +1,7 @@
 (ns pmatiello.tty.internal.ansi.input.parsing-test
   (:require [clojure.test :refer :all]
             [pmatiello.tty.internal.ansi.input.parsing :as input.parsing]
+            [pmatiello.tty.event :as event]
             [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (java.io StringReader)))
 
@@ -8,45 +9,45 @@
 
 (deftest input-seq->event-seq-test
   (testing "decodes regular characters"
-    (is (= [{:event :keypress :value "A"}
-            {:event :keypress :value "B"}
-            {:event :keypress :value "C"}]
+    (is (= [#::event{:type ::event/keypress :value "A"}
+            #::event{:type ::event/keypress :value "B"}
+            #::event{:type ::event/keypress :value "C"}]
            (input.parsing/char-seq->event-seq
              [#::input.parsing{:char-code 65 :has-next? false}
               #::input.parsing{:char-code 66 :has-next? false}
               #::input.parsing{:char-code 67 :has-next? false}]))))
 
   (testing "decodes control characters"
-    (is (= [{:event :keypress :value :nul}]
+    (is (= [#::event{:type ::event/keypress :value :nul}]
            (input.parsing/char-seq->event-seq
              [#::input.parsing{:char-code 0 :has-next? false}]))))
 
   (testing "decodes escape sequences"
-    (is (= [{:event :keypress :value :up}]
+    (is (= [#::event{:type ::event/keypress :value :up}]
            (input.parsing/char-seq->event-seq
              [#::input.parsing{:char-code 27, :has-next? true}
               #::input.parsing{:char-code 91, :has-next? true}
               #::input.parsing{:char-code 65, :has-next? false}]))))
 
   (testing "returns :unknown when escape sequence is not recognised"
-    (is (= [{:event :unknown :value [27 99 99]}]
+    (is (= [#::event{:type ::event/unknown :value [27 99 99]}]
            (input.parsing/char-seq->event-seq
              [#::input.parsing{:char-code 27, :has-next? true}
               #::input.parsing{:char-code 99, :has-next? true}
               #::input.parsing{:char-code 99, :has-next? false}]))))
 
   (testing "splits multiple buffered escape sequences"
-      (is (= [{:event :keypress :value :up}
-              {:event :keypress :value :esc}
-              {:event :keypress :value :down}]
-             (input.parsing/char-seq->event-seq
-               [#::input.parsing{:char-code 27, :has-next? true}
-                #::input.parsing{:char-code 91, :has-next? true}
-                #::input.parsing{:char-code 65, :has-next? true}
-                #::input.parsing{:char-code 27, :has-next? true}
-                #::input.parsing{:char-code 27, :has-next? true}
-                #::input.parsing{:char-code 91, :has-next? true}
-                #::input.parsing{:char-code 66, :has-next? false}])))))
+    (is (= [#::event{:type ::event/keypress :value :up}
+            #::event{:type ::event/keypress :value :esc}
+            #::event{:type ::event/keypress :value :down}]
+           (input.parsing/char-seq->event-seq
+             [#::input.parsing{:char-code 27, :has-next? true}
+              #::input.parsing{:char-code 91, :has-next? true}
+              #::input.parsing{:char-code 65, :has-next? true}
+              #::input.parsing{:char-code 27, :has-next? true}
+              #::input.parsing{:char-code 27, :has-next? true}
+              #::input.parsing{:char-code 91, :has-next? true}
+              #::input.parsing{:char-code 66, :has-next? false}])))))
 
 (deftest reader->char-seq
   (is (= [#::input.parsing{:char-code 105, :has-next? true}

--- a/test/pmatiello/tty/internal/ansi/input_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input_test.clj
@@ -1,15 +1,16 @@
 (ns pmatiello.tty.internal.ansi.input-test
   (:require [clojure.test :refer :all]
             [pmatiello.tty.internal.ansi.input :as input]
+            [pmatiello.tty.event :as event]
             [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (java.io StringReader)))
 
 (use-fixtures :each fixtures/with-spec-instrumentation)
 
 (deftest reader->event-seq-test
-  (is (= [{:event :keypress :value "i"}
-          {:event :keypress :value "n"}
-          {:event :keypress :value "p"}
-          {:event :keypress :value "u"}
-          {:event :keypress :value "t"}]
+  (is (= [#::event{:type ::event/keypress :value "i"}
+          #::event{:type ::event/keypress :value "n"}
+          #::event{:type ::event/keypress :value "p"}
+          #::event{:type ::event/keypress :value "u"}
+          #::event{:type ::event/keypress :value "t"}]
          (-> "input" StringReader. input/reader->event-seq))))

--- a/test/pmatiello/tty/internal/ansi/input_test.clj
+++ b/test/pmatiello/tty/internal/ansi/input_test.clj
@@ -1,7 +1,10 @@
 (ns pmatiello.tty.internal.ansi.input-test
   (:require [clojure.test :refer :all]
-            [pmatiello.tty.internal.ansi.input :as input])
+            [pmatiello.tty.internal.ansi.input :as input]
+            [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (java.io StringReader)))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (deftest reader->event-seq-test
   (is (= [{:event :keypress :value "i"}

--- a/test/pmatiello/tty/internal/fixtures.clj
+++ b/test/pmatiello/tty/internal/fixtures.clj
@@ -1,5 +1,11 @@
 (ns pmatiello.tty.internal.fixtures
-  (:require [pmatiello.tty.internal.ansi.support :as support]))
+  (:require [pmatiello.tty.internal.ansi.support :as support]
+            [clojure.spec.test.alpha :as stest]))
+
+(defn with-spec-instrumentation [f]
+  (stest/instrument)
+  (f)
+  (stest/unstrument))
 
 (defn with-readable-csi [f]
   (with-redefs

--- a/test/pmatiello/tty/internal/io_test.clj
+++ b/test/pmatiello/tty/internal/io_test.clj
@@ -2,8 +2,11 @@
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
             [pmatiello.tty.internal.io :as io]
-            [pmatiello.tty.internal.stty :as stty])
+            [pmatiello.tty.internal.stty :as stty]
+            [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (java.io StringWriter)))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (defn- new-writer []
   (StringWriter.))

--- a/test/pmatiello/tty/internal/mainloop_test.clj
+++ b/test/pmatiello/tty/internal/mainloop_test.clj
@@ -3,7 +3,6 @@
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.m]
             [pmatiello.tty.event :as event]
-            [pmatiello.tty.lifecycle :as tty.lifecycle]
             [pmatiello.tty.internal.ansi.cursor :as cursor]
             [pmatiello.tty.internal.mainloop :as mainloop]
             [pmatiello.tty.internal.signal :as signal]
@@ -32,15 +31,15 @@
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [] output!))
       (mfn/verifying
-        (handle-fn #::event{:type ::tty.lifecycle/init :value true}) nil (mfn.m/exactly 1)
-        (handle-fn #::event{:type ::tty.lifecycle/halt :value true}) nil (mfn.m/exactly 1)))
+        (handle-fn #::event{:type ::event/init :value true}) nil (mfn.m/exactly 1)
+        (handle-fn #::event{:type ::event/halt :value true}) nil (mfn.m/exactly 1)))
 
     (mfn/testing "produce events to render function"
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [] output!))
       (mfn/verifying
-        (render-fn output-buffer {} {::tty.lifecycle/init true}) nil (mfn.m/exactly 1)
-        (render-fn output-buffer (mfn.m/any) {::tty.lifecycle/init true ::tty.lifecycle/halt true}) nil (mfn.m/exactly 1))))
+        (render-fn output-buffer {} {::event/init true}) nil (mfn.m/exactly 1)
+        (render-fn output-buffer (mfn.m/any) {::event/init true ::event/halt true}) nil (mfn.m/exactly 1))))
 
   (mfn/testing "on input reader events"
     (mfn/testing "invokes the handler function for each event"
@@ -57,8 +56,8 @@
             handle-fn (fn [event] (if (symbol? event) (swap! state assoc :last-event event)))]
         (mainloop/with-mainloop handle-fn render-fn state ['ev1 'ev2] output!))
       (mfn/verifying
-        (render-fn output-buffer (mfn.m/any) {::tty.lifecycle/init true :last-event 'ev1}) nil (mfn.m/exactly 1)
-        (render-fn output-buffer (mfn.m/any) {::tty.lifecycle/init true :last-event 'ev2}) nil (mfn.m/exactly 1)
+        (render-fn output-buffer (mfn.m/any) {::event/init true :last-event 'ev1}) nil (mfn.m/exactly 1)
+        (render-fn output-buffer (mfn.m/any) {::event/init true :last-event 'ev2}) nil (mfn.m/exactly 1)
         (render-fn mfn.m/any-args?) nil (mfn.m/any)))
 
     (mfn/testing "no longer invokes render function when mainloop is over"
@@ -66,8 +65,8 @@
         (mainloop/with-mainloop handle-fn render-fn state [] output!)
         (swap! state assoc :x :y))
       (mfn/verifying
-        (render-fn output-buffer (mfn.m/any) {::tty.lifecycle/init true}) nil (mfn.m/any)
-        (render-fn output-buffer (mfn.m/any) {::tty.lifecycle/init true ::tty.lifecycle/halt true}) nil (mfn.m/any))))
+        (render-fn output-buffer (mfn.m/any) {::event/init true}) nil (mfn.m/any)
+        (render-fn output-buffer (mfn.m/any) {::event/init true ::event/halt true}) nil (mfn.m/any))))
 
   (mfn/testing "on terminal dimensions"
     (mfn/testing "request dimensions on initialization"
@@ -90,13 +89,13 @@
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [#::event{:type ::event/cursor-position :value [10 20]}] output!))
       (mfn/verifying
-        (handle-fn #::event{:type ::tty.lifecycle/size :value [10 20]}) nil (mfn.m/exactly 1)
+        (handle-fn #::event{:type ::event/size :value [10 20]}) nil (mfn.m/exactly 1)
         (handle-fn mfn.m/any-args?) nil (mfn.m/any)))
 
     (mfn/testing "updates the state atom on init/resize"
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [#::event{:type ::event/cursor-position :value [10 20]}] output!)
-        (is (= [10 20] (::tty.lifecycle/size @state))))))
+        (is (= [10 20] (::event/size @state))))))
 
   (mfn/providing
     (render-fn mfn.m/any-args?) nil

--- a/test/pmatiello/tty/internal/mainloop_test.clj
+++ b/test/pmatiello/tty/internal/mainloop_test.clj
@@ -10,6 +10,7 @@
   (:import (clojure.lang Atom)))
 
 (use-fixtures :each fixtures/with-readable-csi)
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (declare handle-fn)
 (declare render-fn)

--- a/test/pmatiello/tty/internal/mainloop_test.clj
+++ b/test/pmatiello/tty/internal/mainloop_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.m]
+            [pmatiello.tty.event :as tty.event]
             [pmatiello.tty.lifecycle :as tty.lifecycle]
             [pmatiello.tty.internal.ansi.cursor :as cursor]
             [pmatiello.tty.internal.mainloop :as mainloop]
@@ -31,8 +32,8 @@
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [] output!))
       (mfn/verifying
-        (handle-fn {:event ::tty.lifecycle/init :value true}) nil (mfn.m/exactly 1)
-        (handle-fn {:event ::tty.lifecycle/halt :value true}) nil (mfn.m/exactly 1)))
+        (handle-fn #::tty.event{:type ::tty.lifecycle/init :value true}) nil (mfn.m/exactly 1)
+        (handle-fn #::tty.event{:type ::tty.lifecycle/halt :value true}) nil (mfn.m/exactly 1)))
 
     (mfn/testing "produce events to render function"
       (let [state (atom {})]
@@ -87,14 +88,14 @@
 
     (mfn/testing "notifies the handler function on init/resize"
       (let [state (atom {})]
-        (mainloop/with-mainloop handle-fn render-fn state [{:event :cursor-position :value [10 20]}] output!))
+        (mainloop/with-mainloop handle-fn render-fn state [#::tty.event{:type :cursor-position :value [10 20]}] output!))
       (mfn/verifying
-        (handle-fn {:event ::tty.lifecycle/size :value [10 20]}) nil (mfn.m/exactly 1)
+        (handle-fn #::tty.event{:type ::tty.lifecycle/size :value [10 20]}) nil (mfn.m/exactly 1)
         (handle-fn mfn.m/any-args?) nil (mfn.m/any)))
 
     (mfn/testing "updates the state atom on init/resize"
       (let [state (atom {})]
-        (mainloop/with-mainloop handle-fn render-fn state [{:event :cursor-position :value [10 20]}] output!)
+        (mainloop/with-mainloop handle-fn render-fn state [#::tty.event{:type :cursor-position :value [10 20]}] output!)
         (is (= [10 20] (::tty.lifecycle/size @state))))))
 
   (mfn/providing

--- a/test/pmatiello/tty/internal/mainloop_test.clj
+++ b/test/pmatiello/tty/internal/mainloop_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.m]
-            [pmatiello.tty.event :as tty.event]
+            [pmatiello.tty.event :as event]
             [pmatiello.tty.lifecycle :as tty.lifecycle]
             [pmatiello.tty.internal.ansi.cursor :as cursor]
             [pmatiello.tty.internal.mainloop :as mainloop]
@@ -32,8 +32,8 @@
       (let [state (atom {})]
         (mainloop/with-mainloop handle-fn render-fn state [] output!))
       (mfn/verifying
-        (handle-fn #::tty.event{:type ::tty.lifecycle/init :value true}) nil (mfn.m/exactly 1)
-        (handle-fn #::tty.event{:type ::tty.lifecycle/halt :value true}) nil (mfn.m/exactly 1)))
+        (handle-fn #::event{:type ::tty.lifecycle/init :value true}) nil (mfn.m/exactly 1)
+        (handle-fn #::event{:type ::tty.lifecycle/halt :value true}) nil (mfn.m/exactly 1)))
 
     (mfn/testing "produce events to render function"
       (let [state (atom {})]
@@ -88,14 +88,14 @@
 
     (mfn/testing "notifies the handler function on init/resize"
       (let [state (atom {})]
-        (mainloop/with-mainloop handle-fn render-fn state [#::tty.event{:type :cursor-position :value [10 20]}] output!))
+        (mainloop/with-mainloop handle-fn render-fn state [#::event{:type ::event/cursor-position :value [10 20]}] output!))
       (mfn/verifying
-        (handle-fn #::tty.event{:type ::tty.lifecycle/size :value [10 20]}) nil (mfn.m/exactly 1)
+        (handle-fn #::event{:type ::tty.lifecycle/size :value [10 20]}) nil (mfn.m/exactly 1)
         (handle-fn mfn.m/any-args?) nil (mfn.m/any)))
 
     (mfn/testing "updates the state atom on init/resize"
       (let [state (atom {})]
-        (mainloop/with-mainloop handle-fn render-fn state [#::tty.event{:type :cursor-position :value [10 20]}] output!)
+        (mainloop/with-mainloop handle-fn render-fn state [#::event{:type ::event/cursor-position :value [10 20]}] output!)
         (is (= [10 20] (::tty.lifecycle/size @state))))))
 
   (mfn/providing

--- a/test/pmatiello/tty/internal/signal_test.clj
+++ b/test/pmatiello/tty/internal/signal_test.clj
@@ -1,7 +1,10 @@
 (ns pmatiello.tty.internal.signal-test
   (:require [clojure.test :refer :all]
-            [pmatiello.tty.internal.signal :as signal])
+            [pmatiello.tty.internal.signal :as signal]
+            [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (sun.misc Signal)))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (deftest trap-test
   (testing "executes the given function when the signal is raised"

--- a/test/pmatiello/tty/internal/stty_test.clj
+++ b/test/pmatiello/tty/internal/stty_test.clj
@@ -3,8 +3,11 @@
             [mockfn.clj-test :as mfn]
             [mockfn.matchers :as mfn.matchers]
             [pmatiello.tty.internal.stty :as stty]
-            [clojure.java.shell :refer [sh]])
+            [clojure.java.shell :refer [sh]]
+            [pmatiello.tty.internal.fixtures :as fixtures])
   (:import (clojure.lang ExceptionInfo)))
+
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (mfn/deftest current-test
   (mfn/testing "returns current line terminal settings"

--- a/test/pmatiello/tty/io_test.clj
+++ b/test/pmatiello/tty/io_test.clj
@@ -6,6 +6,7 @@
             [pmatiello.tty.internal.ansi.erase :as erase]))
 
 (use-fixtures :each fixtures/with-readable-csi)
+(use-fixtures :each fixtures/with-spec-instrumentation)
 
 (defn- new-output []
   (atom []))
@@ -13,35 +14,45 @@
 (deftest print!-test
   (testing "prints buffer at location"
     (let [output (new-output)]
-      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 2})
+      (tty.io/print! output
+                     ["line1" "line2"]
+                     #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
              @output))))
 
   (testing "prints only the given height"
     (let [output (new-output)]
-      (tty.io/print! output ["line1" "line2" "ignored"] {:x 3 :y 4 :w 5 :h 2})
+      (tty.io/print! output
+                     ["line1" "line2" "ignored"]
+                     #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
              @output))))
 
   (testing "prints only the given width"
     (let [output (new-output)]
-      (tty.io/print! output ["line1-ignored" "line2-ignored"] {:x 3 :y 4 :w 5 :h 2})
+      (tty.io/print! output
+                     ["line1-ignored" "line2-ignored"]
+                     #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
              @output))))
 
   (testing "fills missing width in buffer with blank space"
     (let [output (new-output)]
-      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 8 :h 2})
+      (tty.io/print! output
+                     ["line1" "line2"]
+                     #::tty.io{:row 4 :column 3 :width 8 :height 2})
       (is (= [(str (cursor/position 4 3) "line1   ")
               (str (cursor/position 5 3) "line2   ")]
              @output))))
 
   (testing "fills missing height in buffer with blank space"
     (let [output (new-output)]
-      (tty.io/print! output ["line1" "line2"] {:x 3 :y 4 :w 5 :h 3})
+      (tty.io/print! output
+                     ["line1" "line2"]
+                     #::tty.io{:row 4 :column 3 :width 5 :height 3})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")
               (str (cursor/position 6 3) "     ")]
@@ -73,5 +84,5 @@
 (deftest place-cursor!-test
   (testing "moves cursor to given position"
     (let [output (new-output)]
-      (tty.io/place-cursor! output {:x 10 :y 5})
+      (tty.io/place-cursor! output #::tty.io{:row 5 :column 10})
       (is (= [(cursor/position 5 10)] @output)))))

--- a/test/pmatiello/tty/io_test.clj
+++ b/test/pmatiello/tty/io_test.clj
@@ -8,81 +8,81 @@
 (use-fixtures :each fixtures/with-readable-csi)
 (use-fixtures :each fixtures/with-spec-instrumentation)
 
-(defn- new-output []
+(defn- new-output-buf []
   (atom []))
 
 (deftest print!-test
   (testing "prints buffer at location"
-    (let [output (new-output)]
-      (tty.io/print! output
+    (let [output-buf (new-output-buf)]
+      (tty.io/print! output-buf
                      ["line1" "line2"]
                      #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
-             @output))))
+             @output-buf))))
 
   (testing "prints only the given height"
-    (let [output (new-output)]
-      (tty.io/print! output
+    (let [output-buf (new-output-buf)]
+      (tty.io/print! output-buf
                      ["line1" "line2" "ignored"]
                      #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
-             @output))))
+             @output-buf))))
 
   (testing "prints only the given width"
-    (let [output (new-output)]
-      (tty.io/print! output
+    (let [output-buf (new-output-buf)]
+      (tty.io/print! output-buf
                      ["line1-ignored" "line2-ignored"]
                      #::tty.io{:row 4 :column 3 :width 5 :height 2})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")]
-             @output))))
+             @output-buf))))
 
   (testing "fills missing width in buffer with blank space"
-    (let [output (new-output)]
-      (tty.io/print! output
+    (let [output-buf (new-output-buf)]
+      (tty.io/print! output-buf
                      ["line1" "line2"]
                      #::tty.io{:row 4 :column 3 :width 8 :height 2})
       (is (= [(str (cursor/position 4 3) "line1   ")
               (str (cursor/position 5 3) "line2   ")]
-             @output))))
+             @output-buf))))
 
   (testing "fills missing height in buffer with blank space"
-    (let [output (new-output)]
-      (tty.io/print! output
+    (let [output-buf (new-output-buf)]
+      (tty.io/print! output-buf
                      ["line1" "line2"]
                      #::tty.io{:row 4 :column 3 :width 5 :height 3})
       (is (= [(str (cursor/position 4 3) "line1")
               (str (cursor/position 5 3) "line2")
               (str (cursor/position 6 3) "     ")]
-             @output)))))
+             @output-buf)))))
 
 (deftest clear-screen!-test
   (testing "clears screen"
-    (let [output (new-output)]
-      (tty.io/clear-screen! output)
-      (is (some #{erase/all} @output))))
+    (let [output-buf (new-output-buf)]
+      (tty.io/clear-screen! output-buf)
+      (is (some #{erase/all} @output-buf))))
 
   (testing "moves cursor to top left"
-    (let [output (new-output)]
-      (tty.io/clear-screen! output)
-      (is (some #{(cursor/position 1 1)} @output)))))
+    (let [output-buf (new-output-buf)]
+      (tty.io/clear-screen! output-buf)
+      (is (some #{(cursor/position 1 1)} @output-buf)))))
 
 (deftest show-cursor!-test
   (testing "shows input cursor"
-    (let [output (new-output)]
-      (tty.io/show-cursor! output)
-      (is (= [cursor/show] @output)))))
+    (let [output-buf (new-output-buf)]
+      (tty.io/show-cursor! output-buf)
+      (is (= [cursor/show] @output-buf)))))
 
 (deftest hide-cursor!-test
   (testing "hide input cursor"
-    (let [output (new-output)]
-      (tty.io/hide-cursor! output)
-      (is (= [cursor/hide] @output)))))
+    (let [output-buf (new-output-buf)]
+      (tty.io/hide-cursor! output-buf)
+      (is (= [cursor/hide] @output-buf)))))
 
 (deftest place-cursor!-test
   (testing "moves cursor to given position"
-    (let [output (new-output)]
-      (tty.io/place-cursor! output #::tty.io{:row 5 :column 10})
-      (is (= [(cursor/position 5 10)] @output)))))
+    (let [output-buf (new-output-buf)]
+      (tty.io/place-cursor! output-buf #::tty.io{:row 5 :column 10})
+      (is (= [(cursor/position 5 10)] @output-buf)))))


### PR DESCRIPTION
Add specs to several namespaces.

- [x] `tty.core` (renamed from `tty`)
- [x] `tty.io`
- [x] `tty.event`
- [x] `tty.internal.io`
- [x] `tty.internal.mainloop`
- [x] `tty.internal.signal`
- [x] `tty.internal.stty`
- [x] `tty.internal.ansi.input`
- [x] `tty.internal.ansi.input.event`
- [x] `tty.internal.ansi.input.parsing`

https://github.com/pmatiello/tty/projects/4#card-72792919